### PR TITLE
Updating app.docker to include proper package name

### DIFF
--- a/app.docker
+++ b/app.docker
@@ -1,6 +1,6 @@
 FROM php:7.2-fpm
 
-RUN apt-get update && apt-get install -y libmcrypt-dev mysql-client \
+RUN apt-get update && apt-get install -y libmcrypt-dev mysql-client-* \
     && pecl install mcrypt-1.0.1 && docker-php-ext-enable mcrypt && docker-php-ext-install pdo_mysql
 
 WORKDIR /var/www


### PR DESCRIPTION
The package name without the wildcard no longer exists.